### PR TITLE
Readjust logic arrangement to avoid error being thrown

### DIFF
--- a/makeFlagReducer.js
+++ b/makeFlagReducer.js
@@ -8,13 +8,12 @@ export default function makeFlagReducer(onValue, offValue, onActionTypes = [], o
   const defaultState = initialState || offValue;
 
   return (state = defaultState, action = {}) => {
-    if (!action.type) {
-      return state;
-    } else if (onActionTypes.includes(action.type)) {
+    if (onActionTypes.includes(action.type)) {
       return onValue;
     } else if (offActionTypes.includes(action.type)) {
       return offValue;
     }
+    return state;
   };
 }
 


### PR DESCRIPTION
When redux initializes it run with an action type that is not falsy (`@@redux/INIT`) which causes it to return the initial state. This in turn results in an error being thrown that the initial state is undefined. This PR fixes that by readjusting the logic blocks because old configuration was checking for a falsy action.type property.

I'm using redux version 3.7.2